### PR TITLE
log updated doc as JSON for Structured Logging

### DIFF
--- a/functions/events-all-logger/README.md
+++ b/functions/events-all-logger/README.md
@@ -1,0 +1,27 @@
+## deploying
+
+Example deployment steps. You will likely need to change project & regions.
+
+Set project and qutoa project
+
+```sh
+gcloud config set project backlogged-dev
+gcloud auth application-default set-quota-project backlogged-dev
+
+# then login and confirm settings
+gcloud auth login
+gcloud config list
+```
+
+Deploy the function
+
+```sh
+gcloud functions deploy events-all-logger \
+--gen2 \
+--region=us-west4 \
+--runtime=go121 \
+--source=. \
+--entry-point=allLoggerFunction \
+--trigger-event=providers/cloud.pubsub/eventTypes/topic.publish \
+--trigger-resource=pinball-events \
+```

--- a/functions/events-all-logger/go.mod
+++ b/functions/events-all-logger/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/GoogleCloudPlatform/functions-framework-go v1.8.1
-	github.com/cloudevents/sdk-go/v2 v2.15.0
+	github.com/cloudevents/sdk-go/v2 v2.15.2
 )
 
 require (

--- a/functions/events-all-logger/go.sum
+++ b/functions/events-all-logger/go.sum
@@ -786,8 +786,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudevents/sdk-go/v2 v2.14.0/go.mod h1:xDmKfzNjM8gBvjaF8ijFjM1VYOVUEeUfapHMUX1T5To=
-github.com/cloudevents/sdk-go/v2 v2.15.0 h1:aKnhLQhyoJXqEECQdOIZnbZ9VupqlidE6hedugDGr+I=
-github.com/cloudevents/sdk-go/v2 v2.15.0/go.mod h1:lL7kSWAE/V8VI4Wh0jbL2v/jvqsm6tjmaQBSvxcv4uE=
+github.com/cloudevents/sdk-go/v2 v2.15.2 h1:54+I5xQEnI73RBhWHxbI1XJcqOFOVJN85vb41+8mHUc=
+github.com/cloudevents/sdk-go/v2 v2.15.2/go.mod h1:lL7kSWAE/V8VI4Wh0jbL2v/jvqsm6tjmaQBSvxcv4uE=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=


### PR DESCRIPTION
This allows Cloud Logging to parse the JSON, enabling queries and filters on the contents of the JSON doc.

Also, parsed the 'data' field after decoding it, so we log a full JSON doc instead of 'data' as a string valued field.
